### PR TITLE
Bugfix: Cannot read spreadsheets with 2 or more empty columns

### DIFF
--- a/Readers/ExcelReader.cs
+++ b/Readers/ExcelReader.cs
@@ -145,6 +145,10 @@ namespace ForkLift.Readers
                     for (int i = 0; i < data.fieldNames.Count; ++i)
                     {
                         var fieldName = data.fieldNames[i];
+
+                        // ignore empty columns
+                        if (string.IsNullOrEmpty(fieldName)) continue;
+
                         var field = new Field() {value = CellValueAsString(row.GetCell(i))};
 
                         validatorRow.fields.Add(fieldName, field);


### PR DESCRIPTION
Expected behaviour:
- Read imported xlsx spreadsheets including empty columns.

Actual behaviour:
- Get a duplicate key of "" exception when importing a file with 2 or more columns that are empty.